### PR TITLE
Change elements order in Companion node

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # VAST Golang Library
 
-[![godoc](http://img.shields.io/badge/godoc-reference-blue.svg?style=flat)](https://godoc.org/github.com/rs/vast) [![license](http://img.shields.io/badge/license-MIT-red.svg?style=flat)](https://raw.githubusercontent.com/rs/vast/master/LICENSE) [![Build Status](https://travis-ci.org/rs/vast.svg?branch=master)](https://travis-ci.org/rs/vast) [![Coverage](http://gocover.io/_badge/github.com/rs/vast)](http://gocover.io/github.com/rs/vast)
+This library is used for **Reach Extension** project.  
+Reach out to us if you have any questions in Slack [#ads-direct-demand-bid](https://unity.slack.com/archives/CHXT9Q63Z).

--- a/vast.go
+++ b/vast.go
@@ -272,24 +272,24 @@ type Companion struct {
 	APIFramework string `xml:"apiFramework,attr,omitempty"`
 	// Used to match companion creative to publisher placement areas on the page.
 	AdSlotID string `xml:"adSlotId,attr,omitempty"`
-	// URL to open as destination page when user clicks on the the companion banner ad.
-	CompanionClickThrough CDATAString `xml:",omitempty"`
-	// URLs to ping when user clicks on the the companion banner ad.
-	CompanionClickTracking []CDATAString `xml:",omitempty"`
 	// Alt text to be displayed when companion is rendered in HTML environment.
 	AltText string `xml:",omitempty"`
-	// The creativeView should always be requested when present. For Companions
-	// creativeView is the only supported event.
-	TrackingEvents []Tracking `xml:"TrackingEvents>Tracking,omitempty"`
-	// Data to be passed into the companion ads. The apiFramework defines the method
-	// to use for communication (e.g. “FlashVar”)
-	AdParameters *AdParameters `xml:",omitempty"`
 	// URL to a static file, such as an image or SWF file
 	StaticResource *StaticResource `xml:",omitempty"`
 	// URL source for an IFrame to display the companion element
 	IFrameResource *CDATAString `xml:",omitempty"`
 	// HTML to display the companion element
 	HTMLResource *HTMLResource `xml:",omitempty"`
+	// The creativeView should always be requested when present. For Companions
+	// creativeView is the only supported event.
+	TrackingEvents []Tracking `xml:"TrackingEvents>Tracking,omitempty"`
+	// Data to be passed into the companion ads. The apiFramework defines the method
+	// to use for communication (e.g. “FlashVar”)
+	AdParameters *AdParameters `xml:",omitempty"`
+	// URL to open as destination page when user clicks on the the companion banner ad.
+	CompanionClickThrough *CDATAString `xml:",omitempty"`
+	// URLs to ping when user clicks on the the companion banner ad.
+	CompanionClickTracking []CDATAString `xml:",omitempty"`
 }
 
 // CompanionWrapper defines a companion ad in a wrapper


### PR DESCRIPTION
AdX support recommended reordering elements within the Companion node. The order of the XML output depends on the order of fields in the struct, so it should be

```
StaticResource
TrackingEvents
CompanionClickThrough
```


> When comparing the VAST 3.0 specs with the way the Companion node was structured in the creative's VAST XML, I noticed that the creative's VAST XML does not follow the order specified in the VAST 3.0 specs.
>
> Would you mind editing the Companion node in the creative's VAST to rule this out as a root cause? Please find the intended sequence below. While it is not explicitly mentioned in the VAST 3.0 specs, there have been past instances where the order of the elements in the companion node had an effect on creative rendering and click throughs. Please find a screenshot attached (page 68 of the VAST 3.0 specs). 

```
<Creative id="..." sequence="1">
<CompanionAds>
<Companion id="..." width="414" height="736">
<StaticResource creativeType="image/jpg">
<![CDATA[]]>
</StaticResource>
<TrackingEvents>
<Tracking event="creativeView">
<![CDATA[ ]]>
</Tracking>
</TrackingEvents>
<CompanionClickThrough>
<![CDATA[ ]]>
</CompanionClickThrough>
</Companion>
</CompanionAds>
</Creative>

```