### PR TITLE
Remove CDATA wrapper for AdSystem

### DIFF
--- a/vast.go
+++ b/vast.go
@@ -44,7 +44,7 @@ type CDATAString struct {
 // URIs necessary to display the ad.
 type InLine struct {
 	// The name of the ad server that returned the ad
-	AdSystem *AdSystem
+	AdSystem string `xml:",omitempty"`
 	// The common name of the ad
 	AdTitle CDATAString
 	// One or more URIs that directs the video player to a tracking resource file that the
@@ -112,7 +112,7 @@ type Pricing struct {
 // the ad.
 type Wrapper struct {
 	// The name of the ad server that returned the ad
-	AdSystem *AdSystem
+	AdSystem string `xml:",omitempty"`
 	// URL of ad tag of downstream Secondary Ad Server
 	VASTAdTagURI CDATAString
 	// One or more URIs that directs the video player to a tracking resource file that the


### PR DESCRIPTION
Currently we serve ad markup with CDATA wrapped AdSystem:
```
<AdSystem><![CDATA[Unity Ads]]></AdSystem>
```

According to VAST spec:
> All URIs or any other free text fields containing potentially dangerous characters contained in the VAST document should be wrapped in CDATA blocks. The VAST response should be carefully tested for appropriate treatment of URI characters that require special handling.

There is nothing wrong with such wrapper, but there is also no need for that because we don't use any special characters. On the other hand, that's not typical XML in examples I've seen in AdX - no one uses CDATA wrapper. My concern is that this may lead to unknown issues, so better avoid this uncertainty especially as we don't need this functionality.

For example, from AdSence:
```
<InLine>
    <AdSystem>AdSense/AdX</AdSystem>
    <AdTitle>149555</AdTitle>
```

I couldn't find guidance on that for Mopub, so seems they don't care how it's implemented. In case of any issues, I'll just revert.